### PR TITLE
3450 add all sa

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ Additional policies will be implemented in future releases.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admission_controller_replicas"></a> [admission\_controller\_replicas](#input\_admission\_controller\_replicas) | The number of replicas for the Kyverno admission controller. | `number` | `3` | no |
-| <a name="input_admissioncontroller_sa"></a> [admissioncontroller\_sa](#input\_admissioncontroller\_sa) | The service account for the Kyverno admission controller. | `string` | `""` | no |
+| <a name="input_admissioncontroller_sa"></a> [admissioncontroller\_sa](#input\_admissioncontroller\_sa) | The service account for the Kyverno admission controller. | `string` | `"kyverno-admission-controller"` | no |
 | <a name="input_backgroundcontroller_replicas"></a> [backgroundcontroller\_replicas](#input\_backgroundcontroller\_replicas) | The number of replicas for the Kyverno background controller. | `number` | `3` | no |
+| <a name="input_backgroundcontroller_sa"></a> [backgroundcontroller\_sa](#input\_backgroundcontroller\_sa) | The service account for the Kyverno background controller. | `string` | `"kyverno-background-controller"` | no |
 | <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | The version of the Kyverno chart to install. | `string` | `"3.3.7"` | no |
 | <a name="input_cleanupcontroller_replicas"></a> [cleanupcontroller\_replicas](#input\_cleanupcontroller\_replicas) | The number of replicas for the Kyverno cleanup controller. | `number` | `2` | no |
+| <a name="input_cleanupcontroller_sa"></a> [cleanupcontroller\_sa](#input\_cleanupcontroller\_sa) | The service account for the Kyverno cleanup controller. | `string` | `"kyverno-cleanup-controller"` | no |
 | <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Create namespace for Kyverno. If false, the namespace must be created before using this module. | `bool` | `true` | no |
 | <a name="input_custom_registry_policies"></a> [custom\_registry\_policies](#input\_custom\_registry\_policies) | Custom configuration for the mutating Kyverno policy. Use the registry URL as the key (e.g.: 'index.docker.io'), `registry_title` as the name used to create the title in the policy, and `registry_remote_mirror` as the registry remote mirror URL (e.g.: `my.awesome-private-registry.com/my-awesome-namespace`). | <pre>map(object({<br/>    registry_title         = string<br/>    registry_remote_mirror = string<br/>    description            = string<br/>  }))</pre> | `{}` | no |
 | <a name="input_excluded_namespaces"></a> [excluded\_namespaces](#input\_excluded\_namespaces) | The list of namespaces to exclude from the Kyverno policies. | `list(string)` | `[]` | no |
@@ -46,10 +48,17 @@ Additional policies will be implemented in future releases.
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace of Kyverno. | `string` | n/a | yes |
 | <a name="input_policy_docker_hub_mirror"></a> [policy\_docker\_hub\_mirror](#input\_policy\_docker\_hub\_mirror) | Values for the mutating Kyverno policy to redirect the DockerHub registry to a mirror/cache registry. Needs only the destination registry url (e.g.: `my.awesome-cache-registry.com`). | <pre>object({<br/>    enabled              = optional(bool, false)<br/>    destination_registry = optional(string, "")<br/>  })</pre> | <pre>{<br/>  "destination_registry": "",<br/>  "enabled": false<br/>}</pre> | no |
 | <a name="input_reportscontroller_replicas"></a> [reportscontroller\_replicas](#input\_reportscontroller\_replicas) | The number of replicas for the Kyverno reports controller. | `number` | `2` | no |
+| <a name="input_reportscontroller_sa"></a> [reportscontroller\_sa](#input\_reportscontroller\_sa) | The service account for the Kyverno reports controller. | `string` | `"kyverno-reports-controller"` | no |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_admissioncontroller_sa"></a> [admissioncontroller\_sa](#output\_admissioncontroller\_sa) | n/a |
+| <a name="output_backgroundcontroller_sa"></a> [backgroundcontroller\_sa](#output\_backgroundcontroller\_sa) | n/a |
+| <a name="output_cleanupcontroller_sa"></a> [cleanupcontroller\_sa](#output\_cleanupcontroller\_sa) | n/a |
+| <a name="output_dockerhub_mirror_registry"></a> [dockerhub\_mirror\_registry](#output\_dockerhub\_mirror\_registry) | n/a |
+| <a name="output_reportscontroller_sa"></a> [reportscontroller\_sa](#output\_reportscontroller\_sa) | n/a |
 
 ## Resources
 

--- a/files/values.yaml.tftpl
+++ b/files/values.yaml.tftpl
@@ -36,6 +36,7 @@ config:
             - gpm-system
             - gpm-public
             %{~ endif ~}
+
 admissionController:
   rbac:
     serviceAccount: 

--- a/files/values.yaml.tftpl
+++ b/files/values.yaml.tftpl
@@ -36,7 +36,6 @@ config:
             - gpm-system
             - gpm-public
             %{~ endif ~}
-  
 admissionController:
   rbac:
     serviceAccount: 

--- a/files/values.yaml.tftpl
+++ b/files/values.yaml.tftpl
@@ -36,8 +36,20 @@ config:
             - gpm-system
             - gpm-public
             %{~ endif ~}
-%{~ if admissioncontroller_sa !="" ~}  
+  
 admissionController:
   rbac:
-    serviceAccount: ${admissioncontroller_sa}
-%{~ endif ~}
+    serviceAccount: 
+      name: ${admissioncontroller_sa}
+backgroundController:
+  rbac:
+    serviceAccount: 
+      name: ${backgroundcontroller_sa}
+cleanupController:
+  rbac:
+    serviceAccount: 
+      name: ${cleanupcontroller_sa} 
+reportsController:
+  rbac:
+    serviceAccount: 
+      name: ${reportscontroller_sa}

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,9 @@ resource "helm_release" "kyverno" {
       cleanupcontroller_replicas    = var.cleanupcontroller_replicas
       reportscontroller_replicas    = var.reportscontroller_replicas
       admissioncontroller_sa        = var.admissioncontroller_sa
+      backgroundcontroller_sa       = var.backgroundcontroller_sa
+      cleanupcontroller_sa          = var.cleanupcontroller_sa
+      reportscontroller_sa          = var.reportscontroller_sa
     })
   ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,6 +16,5 @@ output "reportscontroller_sa" {
 
 output "dockerhub_mirror_registry" {
   value = var.policy_docker_hub_mirror.destination_registry
-
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,1 +1,21 @@
+output "admissioncontroller_sa" {
+  value = var.admissioncontroller_sa
+}
+
+output "backgroundcontroller_sa" {
+  value = var.backgroundcontroller_sa
+}
+
+output "cleanupcontroller_sa" {
+  value = var.cleanupcontroller_sa
+}
+
+output "reportscontroller_sa" {
+  value = var.reportscontroller_sa
+}
+
+output "dockerhub_mirror_registry" {
+  value = var.policy_docker_hub_mirror.destination_registry
+
+}
 

--- a/variables.tf
+++ b/variables.tf
@@ -75,7 +75,26 @@ variable "reportscontroller_replicas" {
 variable "admissioncontroller_sa" {
   description = "The service account for the Kyverno admission controller."
   type        = string
-  default     = ""
+  default     = "kyverno-admission-controller"
+}
+
+variable "backgroundcontroller_sa" {
+  description = "The service account for the Kyverno background controller."
+  type        = string
+  default     = "kyverno-background-controller"
+
+}
+
+variable "cleanupcontroller_sa" {
+  description = "The service account for the Kyverno cleanup controller."
+  type        = string
+  default     = "kyverno-cleanup-controller"
+}
+
+variable "reportscontroller_sa" {
+  description = "The service account for the Kyverno reports controller."
+  type        = string
+  default     = "kyverno-reports-controller"
 }
 
 variable "policy_docker_hub_mirror" {

--- a/variables.tf
+++ b/variables.tf
@@ -82,7 +82,6 @@ variable "backgroundcontroller_sa" {
   description = "The service account for the Kyverno background controller."
   type        = string
   default     = "kyverno-background-controller"
-
 }
 
 variable "cleanupcontroller_sa" {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added service account support for all Kyverno controllers (admission, background, cleanup, and reports)
- Set default service account names for each controller following the pattern `kyverno-{controller}-controller`
- Updated the Helm values template to properly configure service accounts for all controllers
- Added output variables to expose service account names and dockerhub mirror registry



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Add service account variables to Kyverno helm release</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.tf

<li>Added service account variables for background, cleanup, and reports <br>controllers to the helm_release resource


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-helm-kyverno/pull/4/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbb">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>outputs.tf</strong><dd><code>Add service account and registry output variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

outputs.tf

<li>Added output variables for all controller service accounts<br> <li> Added output for dockerhub mirror registry


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-helm-kyverno/pull/4/files#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Define service account variables with defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

variables.tf

<li>Added new service account variables for background, cleanup and <br>reports controllers<br> <li> Set default value for admission controller service account


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-helm-kyverno/pull/4/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+20/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>values.yaml.tftpl</strong><dd><code>Configure service accounts in Kyverno values template</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

files/values.yaml.tftpl

<li>Updated service account configuration format for admission controller<br> <li> Added service account configurations for background, cleanup and <br>reports controllers


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-helm-kyverno/pull/4/files#diff-aed23690cbe4f1b1ff7f6032d855d29e43b7b10f4af6417df72a45c69d227e3f">+15/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information